### PR TITLE
 Enforce "classic" render if `contextTypes` is defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-element-functional",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "JSX `createElement` replacer to use functional React components as functions",
   "main": "index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
 import React from 'react';
 
 export default (component, props, ...children) => {
-  if (typeof component === 'function' && component.prototype instanceof React.Component === false) {
-    return component(Object.assign({}, component.defaultProps, { ...props, children }));
-  }
+    if (
+        typeof component === 'function' &&
+        component.prototype instanceof React.Component === false &&
+        !component.contextTypes
+    ) {
+        return component(Object.assign({}, component.defaultProps, { ...props, children }), {});
+    }
 
-  return React.createElement(component, props, ...children);
+    return React.createElement(component, props, ...children);
 };


### PR DESCRIPTION
If component has `contextTypes` defined it should be rendered as usual.